### PR TITLE
Update notepack.io to ~3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@socket.io/redis-emitter",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "debug": "~4.3.1",
-        "notepack.io": "~2.1.0",
+        "notepack.io": "~3.0.1",
         "socket.io-parser": "~4.0.4"
       },
       "devDependencies": {
@@ -1957,9 +1957,9 @@
       }
     },
     "node_modules/notepack.io": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.1.3.tgz",
-      "integrity": "sha512-AgSt+cP5XMooho1Ppn8NB3FFaVWefV+qZoZncYTUSch2GAEwlYLcIIbT5YVkMlFeNHnfwOvc4HDlbvrB5BRxXA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-3.0.1.tgz",
+      "integrity": "sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg=="
     },
     "node_modules/nyc": {
       "version": "15.1.0",
@@ -4374,9 +4374,9 @@
       "dev": true
     },
     "notepack.io": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.1.3.tgz",
-      "integrity": "sha512-AgSt+cP5XMooho1Ppn8NB3FFaVWefV+qZoZncYTUSch2GAEwlYLcIIbT5YVkMlFeNHnfwOvc4HDlbvrB5BRxXA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-3.0.1.tgz",
+      "integrity": "sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg=="
     },
     "nyc": {
       "version": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "debug": "~4.3.1",
-    "notepack.io": "~2.1.0",
+    "notepack.io": "~3.0.1",
     "socket.io-parser": "~4.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi, I'd like to be able to take advantage of https://github.com/darrachequesne/notepack/pull/28 in my project, which uses `notepack.io` via this package.